### PR TITLE
Receiver custom policy credits settlement

### DIFF
--- a/send_receive/lib/client.d.ts
+++ b/send_receive/lib/client.d.ts
@@ -8,32 +8,11 @@ import Receiver = require('./receiver');
 import Sender = require('./sender');
 
 declare namespace EventHubClient {
-    enum receiverSettleMode {
-        autoSettle,
-        settleOnDisposition
-    }
-
-    interface ReceiverFlowControlPolicy {
-        /**
-         * Auto or On disposition
-         * One of EventHubClient.receiverSettleMode.autoSettle or EventHubClient.receiverSettleMode.settleOnDisposition
-         */
-        receiverSettleMethod: receiverSettleMode;
-        /**
-         * Re-crediting policy if not auto-settling
-         */
-        creditPolicy?: () => void;
-        /**
-         * Initial number of credits for the receiver if not auto-settling
-         */
-        creditQuantum?: number;
-    }
-
     interface ReceiverOptions {
         startAfterTime?: Date | number;
         startAfterOffset?: string;
         customFilter?: string;
-        flowControlPolicy?: ReceiverFlowControlPolicy;
+        flowControlPolicy?: Receiver.ReceiverFlowControlPolicy;
     }
     type PartitionId = string | number;
 }

--- a/send_receive/lib/client.d.ts
+++ b/send_receive/lib/client.d.ts
@@ -8,10 +8,32 @@ import Receiver = require('./receiver');
 import Sender = require('./sender');
 
 declare namespace EventHubClient {
+    enum receiverSettleMode {
+        autoSettle,
+        settleOnDisposition
+    }
+
+    interface ReceiverFlowControlPolicy {
+        /**
+         * Auto or On disposition
+         * One of EventHubClient.receiverSettleMode.autoSettle or EventHubClient.receiverSettleMode.settleOnDisposition
+         */
+        receiverSettleMethod: receiverSettleMode;
+        /**
+         * Re-crediting policy if not auto-settling
+         */
+        creditPolicy?: () => void;
+        /**
+         * Initial number of credits for the receiver if not auto-settling
+         */
+        creditQuantum?: number;
+    }
+
     interface ReceiverOptions {
         startAfterTime?: Date | number;
         startAfterOffset?: string;
         customFilter?: string;
+        flowControlPolicy?: ReceiverFlowControlPolicy;
     }
     type PartitionId = string | number;
 }

--- a/send_receive/lib/client.js
+++ b/send_receive/lib/client.js
@@ -243,9 +243,7 @@ EventHubClient.prototype.createReceiver = function createReceiver(consumerGroup,
 
         if (options.flowControlPolicy) {
             var flowPolicy = {
-              attach: {receiverSettleMode: options.flowControlPolicy.receiverSettleMethod},
-              credit: null,
-              creditQuantum: null
+              attach: {receiverSettleMode: options.flowControlPolicy.receiverSettleMethod}
             };
 
             if (options.flowControlPolicy.creditPolicy) {

--- a/send_receive/lib/client.js
+++ b/send_receive/lib/client.js
@@ -61,16 +61,6 @@ function EventHubClient(config) {
 }
 
 /**
- * recevierSettleMode enum proxy from amqp10.Constants.receiverSettleMode
- */
-var receiverSettleMode;
-(function (receiverSettleMode) {
-  receiverSettleMode[receiverSettleMode.autoSettle = amqp10.Constants.receiverSettleMode.autoSettle] = 'autoSettle';
-  receiverSettleMode[receiverSettleMode.settleOnDisposition = amqp10.Constants.receiverSettleMode.settleOnDisposition] = 'settleOnDisposition';
-})(receiverSettleMode || (receiverSettleMode = {}));
-EventHubClient.receiverSettleMode = receiverSettleMode;
-
-/**
  * Static factory method for convenience.
  *
  * @method fromConnectionString

--- a/send_receive/lib/client.js
+++ b/send_receive/lib/client.js
@@ -254,7 +254,7 @@ EventHubClient.prototype.createReceiver = function createReceiver(consumerGroup,
                 flowPolicy.creditQuantum = options.flowControlPolicy.creditQuantum;
             }
 
-            filter = amqp10.Policy.merge(flowPolicy, filter);
+            filter = amqp10.Policy.merge(flowPolicy, filter || {});
         }
       }
 

--- a/send_receive/lib/client.js
+++ b/send_receive/lib/client.js
@@ -38,7 +38,7 @@ function EventHubClient(config) {
       attach: {
         maxMessageSize: 0 // means infinity
       },
-      decoder: function(body) {
+      decoder: function (body) {
         var bodyStr = null;
 
         if (body instanceof Buffer) {
@@ -59,6 +59,16 @@ function EventHubClient(config) {
   }, amqp10.Policy.EventHub));
   this._connectPromise = null;
 }
+
+/**
+ * recevierSettleMode enum proxy from amqp10.Constants.receiverSettleMode
+ */
+var receiverSettleMode;
+(function (receiverSettleMode) {
+  receiverSettleMode[receiverSettleMode.autoSettle = amqp10.Constants.receiverSettleMode.autoSettle] = 'autoSettle';
+  receiverSettleMode[receiverSettleMode.settleOnDisposition = amqp10.Constants.receiverSettleMode.settleOnDisposition] = 'settleOnDisposition';
+})(receiverSettleMode || (receiverSettleMode = {}));
+EventHubClient.receiverSettleMode = receiverSettleMode;
 
 /**
  * Static factory method for convenience.
@@ -202,12 +212,13 @@ EventHubClient.prototype.getPartitionIds = function () {
  * Receivers are event emitters, watch for 'message' and 'errorReceived' events.
  *
  * @method createReceiver
- * @param {string} consumerGroup                      Consumer group from which to receive.
- * @param {(string|Number)} partitionId               Partition ID from which to receive.
- * @param {*} [options]                               Options for how you'd like to connect. Only one can be specified.
- * @param {(Date|Number)} options.startAfterTime      Only receive messages enqueued after the given time.
- * @param {string} options.startAfterOffset           Only receive messages after the given offset.
- * @param {string} options.customFilter               If you want more fine-grained control of the filtering.
+ * @param {string} consumerGroup                                Consumer group from which to receive.
+ * @param {(string|Number)} partitionId                         Partition ID from which to receive.
+ * @param {*} [options]                                         Options for how you'd like to connect. Only one can be specified.
+ * @param {(Date|Number)} options.startAfterTime                Only receive messages enqueued after the given time.
+ * @param {string} options.startAfterOffset                     Only receive messages after the given offset.
+ * @param {string} options.customFilter                         If you want more fine-grained control of the filtering.
+ * @param {ReceiverFlowControlPolicy} options.flowControlPolicy Receiver flow control policy
  *      See https://github.com/Azure/amqpnetlite/wiki/Azure%20Service%20Bus%20Event%20Hubs for details.
  *
  * @return {Promise}
@@ -238,6 +249,24 @@ EventHubClient.prototype.createReceiver = function createReceiver(consumerGroup,
                 ['described', ['symbol', 'apache.org:selector-filter:string'], ['string', filterClause]])
             } } }
           };
+        }
+
+        if (options.flowControlPolicy) {
+            var flowPolicy = {
+              attach: {receiverSettleMode: options.flowControlPolicy.receiverSettleMethod},
+              credit: null,
+              creditQuantum: null
+            };
+
+            if (options.flowControlPolicy.creditPolicy) {
+                flowPolicy.credit = options.flowControlPolicy.creditPolicy;
+            }
+
+            if (options.flowControlPolicy.creditQuantum !== null) {
+                flowPolicy.creditQuantum = options.flowControlPolicy.creditQuantum;
+            }
+
+            filter = amqp10.Policy.merge(flowPolicy, filter);
         }
       }
 

--- a/send_receive/lib/receiver.d.ts
+++ b/send_receive/lib/receiver.d.ts
@@ -15,6 +15,8 @@ declare class EventHubReceiver extends EventEmitter {
     on(type: 'errorReceived', func: (err: Error) => void): this;
     // Required last overload, though which shouldn't be called during normal operation
     on(type: string, func: Function): this;
+
+    addCredits(creditsQuantum: number): void;
 }
 
 export = EventHubReceiver;

--- a/send_receive/lib/receiver.d.ts
+++ b/send_receive/lib/receiver.d.ts
@@ -5,6 +5,37 @@ import { EventEmitter } from 'events';
 import Promise = require('bluebird');
 import { Message } from 'azure-iot-common';
 
+declare namespace EventHubReceiver {
+    enum receiverSettleMode {
+        autoSettle,
+        settleOnDisposition
+    }
+
+    type CreditPolicy = () => void;
+    const creditPolicies: {
+        RefreshAtHalf: CreditPolicy;
+        RefreshAtEmpty: CreditPolicy;
+        RefreshSettled(treshold: number): CreditPolicy;
+        DoNotRefresh: CreditPolicy;
+    };
+
+    interface ReceiverFlowControlPolicy {
+        /**
+         * Auto or On disposition
+         * One of EventHubClient.receiverSettleMode.autoSettle or EventHubClient.receiverSettleMode.settleOnDisposition
+         */
+        receiverSettleMethod: receiverSettleMode;
+        /**
+         * Re-crediting policy if not auto-settling
+         */
+        creditPolicy?: CreditPolicy;
+        /**
+         * Initial number of credits for the receiver if not auto-settling
+         */
+        creditQuantum?: number;
+    }
+}
+
 declare class EventHubReceiver extends EventEmitter {
     // TODO: When upgrading to amqp10 v3 use already existing typings
     constructor(amqpReceiverLink: any);

--- a/send_receive/lib/receiver.js
+++ b/send_receive/lib/receiver.js
@@ -5,6 +5,7 @@
 
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+var amqp10 = require('amqp10');
 
 var EventData = require('./eventdata.js');
 var errors = require('./errors.js');
@@ -57,6 +58,19 @@ function EventHubReceiver(amqpReceiverLink) {
 }
 
 util.inherits(EventHubReceiver, EventEmitter);
+
+/**
+ * recevierSettleMode enum proxy from amqp10.Constants.receiverSettleMode
+ */
+var receiverSettleMode;
+(function (receiverSettleMode) {
+  receiverSettleMode[receiverSettleMode.autoSettle = amqp10.Constants.receiverSettleMode.autoSettle] = 'autoSettle';
+  receiverSettleMode[receiverSettleMode.settleOnDisposition = amqp10.Constants.receiverSettleMode.settleOnDisposition] = 'settleOnDisposition';
+})(receiverSettleMode || (receiverSettleMode = {}));
+EventHubReceiver.receiverSettleMode = receiverSettleMode;
+
+EventHubReceiver.creditPolicies = amqp10.Policy.Utils.CreditPolicies;
+
 
 /**
  * "Unlink" this receiver, closing the link and resolving when that operation is complete. Leaves the underlying connection/session open.

--- a/send_receive/lib/receiver.js
+++ b/send_receive/lib/receiver.js
@@ -73,4 +73,8 @@ EventHubReceiver.prototype.close = function() {
   });
 };
 
+EventHubReceiver.prototype.addCredits = function(creditsQuantum) {
+  this._receiverLink.addCredits(creditsQuantum);
+};
+
 module.exports = EventHubReceiver;


### PR DESCRIPTION
I needed to be able to save the current consumer offset for the consumed partition/consumer group in the obvious scenario where messages are processed asynchronously.

I did expose the underlying amqp10 CreditsPolicy in order to switch from the default autoSettle to settleOnDisposition and being able to implement custom consumer policy for re-crediting the receiver link. 