### PR TITLE
Fixed an edge case

### DIFF
--- a/send_receive/lib/client.js
+++ b/send_receive/lib/client.js
@@ -262,7 +262,7 @@ EventHubClient.prototype.createSender = function createSender(partitionId) {
   return this.open()
     .then(function () {
       var endpoint = '/' + self._config.path;
-      if (partitionId) {
+      if (partitionId !== undefined) {
         endpoint += '/Partitions/' + partitionId;
       }
       return self._amqp.createSender(endpoint);


### PR DESCRIPTION
In the edge case that integer `0` is passed as the `partitionId`, `if (partitionId) ` results to false, thus the line `endpoint += '/Partitions/' + partitionId;` will be ignored.