### PR TITLE
Fix client examples link in README

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -42,7 +42,7 @@ export DEBUG=azure*,rhea*
 
 ## Examples ##
 
-Please take a look at the [examples](https://github.com/Azure/azure-event-hubs-node/tree/master/examples) directory for detailed examples.
+Please take a look at the [examples](https://github.com/Azure/azure-event-hubs-node/tree/master/client/examples) directory for detailed examples.
 
 ## Example 1 - Get the partition IDs.
 


### PR DESCRIPTION
Link to client examples in the client README was pointing to the root repo directory instead of the client directory, resulting in a 404 when navigated to.