### PR TITLE
Solidify recovery

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,6 @@
       "editor.tabSize": 2,
       "editor.detectIndentation": false
     },
-    "editor.rulers": [100]
+    "editor.rulers": [100],
+    "typescript.tsdk": "./client/node_modules/typescript/lib"
   }

--- a/client/lib/connectionContext.ts
+++ b/client/lib/connectionContext.ts
@@ -167,21 +167,33 @@ export namespace ConnectionContext {
         await delay(connectionReconnectDelay);
         // reconnect senders if any
         for (const sender of Object.values(connectionContext.senders)) {
-          debug("[%s] calling detached on sender '%s' with address '%s'.",
-            connectionContext.connection.id, sender.name, sender.address);
-          sender.detached().catch((err) => {
-            debug("[%s] An error occurred while reconnecting the sender '%s' with adress '%s' %O.",
-              connectionContext.connection.id, sender.name, sender.address, err);
-          });
+          if (!sender.isConnecting) {
+            debug("[%s] calling detached on sender '%s' with address '%s'.",
+              connectionContext.connection.id, sender.name, sender.address);
+            sender.detached().catch((err) => {
+              debug("[%s] An error occurred while reconnecting the sender '%s' with adress '%s' %O.",
+                connectionContext.connection.id, sender.name, sender.address, err);
+            });
+          } else {
+            debug("[%s] sender '%s' with address '%s' is already reconnecting. Hence not " +
+              "calling detached on the sender.", connectionContext.connection.id, sender.name,
+              sender.address);
+          }
         }
         // reconnect receivers if any
         for (const receiver of Object.values(connectionContext.receivers)) {
-          debug("[%s] calling detached on receiver '%s' with address '%s'.",
-            connectionContext.connection.id, receiver.name, receiver.address);
-          receiver.detached().catch((err) => {
-            debug("[%s] An error occurred while reconnecting the receiver '%s' with adress '%s' %O.",
-              connectionContext.connection.id, receiver.name, receiver.address, err);
-          });
+          if (!receiver.isConnecting) {
+            debug("[%s] calling detached on receiver '%s' with address '%s'.",
+              connectionContext.connection.id, receiver.name, receiver.address);
+            receiver.detached().catch((err) => {
+              debug("[%s] An error occurred while reconnecting the receiver '%s' with adress '%s' %O.",
+                connectionContext.connection.id, receiver.name, receiver.address, err);
+            });
+          } else {
+            debug("[%s] receiver '%s' with address '%s' is already reconnecting. Hence not " +
+              "calling detached on the receiver.", connectionContext.connection.id, receiver.name,
+              receiver.address);
+          }
         }
       }
     };

--- a/client/lib/eventHubReceiver.ts
+++ b/client/lib/eventHubReceiver.ts
@@ -4,7 +4,7 @@
 import * as debugModule from "debug";
 import * as uuid from "uuid/v4";
 import {
-  Receiver, OnAmqpEvent, EventContext, ReceiverOptions, types, AmqpError
+  Receiver, OnAmqpEvent, EventContext, ReceiverOptions, types, AmqpError, SessionEvents
 } from "./rhea-promise";
 import {
   translate, Constants, MessagingError, retry, RetryOperationType, RetryConfig
@@ -21,6 +21,8 @@ interface CreateReceiverOptions {
   onMessage: OnAmqpEvent;
   onError: OnAmqpEvent;
   onClose: OnAmqpEvent;
+  onSessionError: OnAmqpEvent;
+  onSessionClose: OnAmqpEvent;
   newName?: boolean;
   eventPosition?: EventPosition;
 }
@@ -130,29 +132,41 @@ export class EventHubReceiver extends LinkEntity {
    */
   protected _onMessage?: OnMessage;
   /**
-   * @property {OnMessage} _onError The error handler provided by the user that will be wrapped
+   * @property {OnError} _onError The error handler provided by the user that will be wrapped
    * inside _onAmqpError.
    * @protected
    */
   protected _onError?: OnError;
   /**
-   * @property {OnMessage} _onAmqpError The message handler that will be set as the handler on the
+   * @property {OnAmqpEvent} _onAmqpError The message handler that will be set as the handler on the
    * underlying rhea receiver for the "message" event.
    * @protected
    */
   protected _onAmqpMessage: OnAmqpEvent;
   /**
-   * @property {OnMessage} _onAmqpError The message handler that will be set as the handler on the
+   * @property {OnAmqpEvent} _onAmqpError The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_error" event.
    * @protected
    */
   protected _onAmqpError: OnAmqpEvent;
   /**
-   * @property {OnMessage} _onAmqpClose The message handler that will be set as the handler on the
+   * @property {OnAmqpEvent} _onAmqpClose The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_close" event.
    * @protected
    */
   protected _onAmqpClose: OnAmqpEvent;
+  /**
+   * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
+   * the underlying rhea receiver's session for the "session_error" event.
+   * @protected
+   */
+  protected _onSessionError: OnAmqpEvent;
+  /**
+   * @property {OnAmqpEvent} _onSessionClose The message handler that will be set as the handler on
+   * the underlying rhea receiver's session for the "session_close" event.
+   * @protected
+   */
+  protected _onSessionClose: OnAmqpEvent;
   /**
    * @property {CheckpointData} _checkpoint Describes metadata about the last message received.
    * This is used as the offset to receive messages from incase of recovery.
@@ -207,35 +221,79 @@ export class EventHubReceiver extends LinkEntity {
 
     this._onAmqpError = (context: EventContext) => {
       const receiverError = context.receiver && context.receiver.error;
-      const sessionError = context.session && context.session.error;
       if (receiverError) {
         const ehError = translate(receiverError);
         debug("[%s] An error occurred for Receiver '%s': %O.",
           this._context.connectionId, this.name, ehError);
-        this._onError!(ehError);
-      } else if (sessionError) {
+        if (!this._receiver!.wasCloseInitiated()) {
+          this._onError!(ehError);
+        }
+      }
+    };
+
+    this._onSessionError = (context: EventContext) => {
+      const sessionError = context.session && context.session.error;
+      if (sessionError) {
         const ehError = translate(sessionError);
         debug("[%s] An error occurred on the session for Receiver '%s': %O.",
           this._context.connectionId, this.name, ehError);
-        this._onError!(ehError);
+        if (!this._receiver!.wasSessionCloseInitiated()) {
+          this._onError!(ehError);
+        }
       }
     };
 
     this._onAmqpClose = async (context: EventContext) => {
       const receiverError = context.receiver && context.receiver.error;
-      const sessionError = context.session && context.session.error;
       if (receiverError) {
         debug("[%s] 'receiver_close' event occurred for receiver '%s' with address '%s'. " +
           "The associated error is: %O", this._context.connectionId, this.name,
           this.address, receiverError);
-        debug("[%s] Calling detached() of receiver '%s' with address '%s to revive the link.",
-          this._context.connectionId, this.name, this.address);
-        await this.detached(receiverError);
-      } else if (sessionError) {
-        debug("[%s] 'session_close' event occurred for receiver '%s'. The associated error is: %O",
-          this._context.connectionId, this.name, sessionError);
-        // TODO: session_close and session_error needs to be handled correctly, same problem in
-        // sender.
+      }
+      if (this._receiver && !this._receiver.wasCloseInitiated()) {
+        if (!this.isConnecting) {
+          debug("[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
+            "and the sdk did not initiate this. The receiver is not reconnecting. Hence, calling " +
+            "detached from the _onAmqpClose() handler.", this._context.connectionId, this.name,
+            this.address);
+          await this.detached(receiverError);
+        } else {
+          debug("[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
+            "and the sdk did not initate this. Moreover the receiver is already re-connecting. " +
+            "Hence not calling detached from the _onAmqpClose() handler.",
+            this._context.connectionId, this.name, this.address);
+        }
+      } else {
+        debug("[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
+          "because the sdk initiated it. Hence not calling detached from the _onAmqpClose" +
+          "() handler.", this._context.connectionId, this.name, this.address);
+      }
+    };
+
+    this._onSessionClose = async (context: EventContext) => {
+      const sessionError = context.session && context.session.error;
+      if (sessionError) {
+        debug("[%s] 'session_close' event occurred for receiver '%s' with address '%s'. " +
+          "The associated error is: %O", this._context.connectionId, this.name,
+          this.address, sessionError);
+      }
+
+      if (this._receiver && !this._receiver.wasSessionCloseInitiated()) {
+        if (!this.isConnecting) {
+          debug("[%s] 'session_close' event occurred on the session of receiver '%s' with " +
+            "address '%s' and the sdk did not initiate this. Hence calling detached from the " +
+            "_onSessionClose() handler.", this._context.connectionId, this.name, this.address);
+          await this.detached(sessionError);
+        } else {
+          debug("[%s] 'session_close' event occurred on the session of receiver '%s' with " +
+            "address '%s' and the sdk did not initiate this. Moreover the receiver is already " +
+            "re-connecting. Hence not calling detached from the _onSessionClose() handler.",
+            this._context.connectionId, this.name, this.address);
+        }
+      } else {
+        debug("[%s] 'session_close' event occurred on the session of receiver '%s' with address " +
+          "'%s' because the sdk initiated it. Hence not calling detached from the _onSessionClose" +
+          "() handler.", this._context.connectionId, this.name, this.address);
       }
     };
   }
@@ -246,14 +304,19 @@ export class EventHubReceiver extends LinkEntity {
    * @returns {Promise<void>} Promise<void>.
    */
   async detached(receiverError?: AmqpError | Error): Promise<void> {
-    await this._closeLink(this._receiver); // clear the token renewal timer.
+    // Clears the token renewal timer. Closes the link and its session if they are open.
+    // Removes the link and its session if they are present in the cache.
+    await this._closeLink(this._receiver);
+    // For session_close and receiver_close this should attempt to reopen
+    // only when the receiver(sdk) did not initiate the close) OR
+    // if an error is present and the error is retryable.
     let shouldReopen = false;
-    if (receiverError && this._context.receivers[this.name]) {
+    if (receiverError && this._receiver && !this._receiver.wasCloseInitiated()) {
       const translatedError = translate(receiverError);
       if (translatedError.retryable) {
         shouldReopen = true;
       }
-    } else if (this._context.receivers[this.name]) {
+    } else if (this._receiver && !this._receiver.wasCloseInitiated()) {
       shouldReopen = true;
       debug("[%s] close() method of Receiver '%s' with address '%s' was not called. " +
         "There was no accompanying error as well. This is a candidate for re-establishing " +
@@ -264,6 +327,8 @@ export class EventHubReceiver extends LinkEntity {
         onMessage: this._onAmqpMessage,
         onError: this._onAmqpError,
         onClose: this._onAmqpClose,
+        onSessionError: this._onSessionError,
+        onSessionClose: this._onSessionClose,
         newName: true // provide a new name to the link while re-connecting it. This ensures that
         // the service does not send an error stating that the link is still open.
       };
@@ -319,24 +384,29 @@ export class EventHubReceiver extends LinkEntity {
    */
   protected async _init(options?: ReceiverOptions): Promise<void> {
     try {
-      if (!this.isOpen()) {
+      if (!this.isOpen() && !this.isConnecting) {
+        debug("[%s] The receiver '%s' with address '%s' is not open and is not currently " +
+          "establishing itself. Hence let's try to connect.", this._context.connectionId,
+          this.name, this.address);
         await this._negotiateClaim();
         if (!options) {
           options = this._createReceiverOptions({
             onMessage: this._onAmqpMessage,
             onError: this._onAmqpError,
-            onClose: this._onAmqpClose
+            onClose: this._onAmqpClose,
+            onSessionError: this._onSessionError,
+            onSessionClose: this._onSessionClose,
           });
         }
         debug("[%s] Trying to create receiver '%s' with options %O",
           this._context.connectionId, this.name, options);
 
         this._receiver = await this._context.connection.createReceiver(options);
-        // TODO: Need to figure out how to handle session_close for sender and receiver.
-        // Should be able to distinguish between sdk calling session close (from the close method)
-        // Or due to close in detached. OR it happened due to an actual error.
-        // this._receiver.registerSessionHandler(SessionEvents.sessionError, options.onError!);
-        // this._receiver.registerSessionHandler(SessionEvents.sessionClose, options.onClose!);
+        this.isConnecting = false;
+        debug("[%s] Receiver '%s' with address '%s' has established itself.",
+          this._context.connectionId, this.name, this.address);
+        this._receiver.registerSessionHandler(SessionEvents.sessionError, options.onSessionError!);
+        this._receiver.registerSessionHandler(SessionEvents.sessionClose, options.onSessionClose!);
         debug("Promise to create the receiver resolved. Created receiver with name: ", this.name);
         debug("[%s] Receiver '%s' created with receiver options: %O",
           this._context.connectionId, this.name, options);
@@ -344,6 +414,10 @@ export class EventHubReceiver extends LinkEntity {
         // Thus make sure that the receiver is present in the client cache.
         if (!this._context.receivers[this.name]) this._context.receivers[this.name] = this;
         await this._ensureTokenRenewal();
+      } else {
+        debug("[%s] The receiver '%s' with address '%s' is open -> %s and is connecting " +
+          "-> %s. Hence not reconnecting.", this._context.connectionId, this.name, this.address,
+          this.isOpen(), this.isConnecting);
       }
     } catch (err) {
       err = translate(err);
@@ -367,7 +441,9 @@ export class EventHubReceiver extends LinkEntity {
       credit_window: this.prefetchCount,
       onMessage: options.onMessage || this._onAmqpMessage,
       onError: options.onError || this._onAmqpError,
-      onClose: options.onClose || this._onAmqpClose
+      onClose: options.onClose || this._onAmqpClose,
+      onSessionError: options.onSessionError || this._onSessionError,
+      onSessionClose: options.onSessionClose || this._onSessionClose
     };
     if (this.epoch !== undefined && this.epoch !== null) {
       if (!rcvrOptions.properties) rcvrOptions.properties = {};

--- a/client/lib/linkEntity.ts
+++ b/client/lib/linkEntity.ts
@@ -70,6 +70,11 @@ export class LinkEntity {
    */
   partitionId?: string | number;
   /**
+   * @property {boolean} isConnecting Indicates whether the link is in the process of connecting
+   * (establishing) itself. Default value: `false`.
+   */
+  isConnecting: boolean = false;
+  /**
    * @property {ConnectionContext} _context Provides relevant information about the amqp connection,
    * cbs and $management sessions, token provider, sender and receivers.
    * @protected
@@ -160,6 +165,8 @@ export class LinkEntity {
     clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
     if (link) {
       try {
+        // This should take care of closing the link and it's underlying session. This should also
+        // remove them from the internal map.
         await link.close();
         debug("[%s] %s '%s' with address '%s' closed.", this._context.connectionId, this._type,
           this.name, this.address);
@@ -167,10 +174,6 @@ export class LinkEntity {
         debug("[%s] An error occurred while closing the %s '%s' with address '%s': %O",
           this._context.connectionId, this._type, this.name, this.address, err);
       }
-      // TODO: Let us wait for rhea to do this correctly for us.
-      link.remove();
-      debug("[%s] %s '%s' with address '%s' and it's session have been removed from " +
-        "internal map.", this._context.connectionId, this._type, this.name, this.address);
     }
   }
 

--- a/client/lib/rhea-promise/connection.ts
+++ b/client/lib/rhea-promise/connection.ts
@@ -142,6 +142,15 @@ export class Connection {
   }
 
   /**
+   * Determines whether the close from the peer is a response to a locally initiated close request
+   * for the connection.
+   * @returns {boolean} `true` if close was locally initiated, `false` otherwise.
+   */
+  wasCloseInitiated(): boolean {
+    return this._connection.is_closed();
+  }
+
+  /**
    * Creates an amqp session on the provided amqp connection.
    * @return {Promise<Session>} Promise<Session>
    * - **Resolves** the promise with the Session object when rhea emits the "session_open" event.
@@ -188,7 +197,7 @@ export class Connection {
    * @return {Promise<Sender>} Promise<Sender>.
    */
   async createSender(options?: SenderOptionsWithSession): Promise<Sender> {
-    if (options && options.session) {
+    if (options && options.session && options.session.createSender) {
       return await options.session.createSender(options);
     }
     const session = await this.createSession();
@@ -201,7 +210,7 @@ export class Connection {
    * @return {Promise<Receiver>} Promise<Receiver>.
    */
   async createReceiver(options?: ReceiverOptionsWithSession): Promise<Receiver> {
-    if (options && options.session) {
+    if (options && options.session && options.session.createReceiver) {
       return await options.session.createReceiver(options);
     }
     const session = await this.createSession();

--- a/client/lib/rhea-promise/receiver.ts
+++ b/client/lib/rhea-promise/receiver.ts
@@ -12,6 +12,8 @@ export interface ReceiverOptions extends rhea.ReceiverOptions {
   onMessage?: rhea.OnAmqpEvent;
   onError?: rhea.OnAmqpEvent;
   onClose?: rhea.OnAmqpEvent;
+  onSessionError?: rhea.OnAmqpEvent;
+  onSessionClose?: rhea.OnAmqpEvent;
 }
 
 export class Receiver {
@@ -69,7 +71,7 @@ export class Receiver {
     this._receiver.set_credit_window(creditWindow);
   }
   /**
-   * Determines whether the sender link is open.
+   * Determines whether the receiver link is open.
    * @returns {boolean} `true` open. `false` closed.
    */
   isOpen(): boolean {
@@ -78,6 +80,24 @@ export class Receiver {
       result = true;
     }
     return result;
+  }
+
+  /**
+   * Determines whether the close from the peer is a response to a locally initiated close request
+   * for the receiver.
+   * @returns {boolean} `true` if close was locally initiated, `false` otherwise.
+   */
+  wasCloseInitiated(): boolean {
+    return this._receiver.is_closed();
+  }
+
+  /**
+   * Determines whether the close from the peer is a response to a locally initiated close request
+   * for the receiver's session.
+   * @returns {boolean} `true` if close was locally initiated, `false` otherwise.
+   */
+  wasSessionCloseInitiated(): boolean {
+    return this._session.wasCloseInitiated();
   }
 
   /**

--- a/client/lib/rhea-promise/sender.ts
+++ b/client/lib/rhea-promise/sender.ts
@@ -15,6 +15,8 @@ export interface SenderOptions extends rhea.SenderOptions {
   onModified?: rhea.OnAmqpEvent;
   onError?: rhea.OnAmqpEvent;
   onClose?: rhea.OnAmqpEvent;
+  onSessionError?: rhea.OnAmqpEvent;
+  onSessionClose?: rhea.OnAmqpEvent;
 }
 
 export class Sender {
@@ -85,6 +87,24 @@ export class Sender {
       result = true;
     }
     return result;
+  }
+
+  /**
+   * Determines whether the close from the peer is a response to a locally initiated close request
+   * for the sender.
+   * @returns {boolean} `true` if close was locally initiated, `false` otherwise.
+   */
+  wasCloseInitiated(): boolean {
+    return this._sender.is_closed();
+  }
+
+  /**
+   * Determines whether the close from the peer is a response to a locally initiated close request
+   * for the sender's session.
+   * @returns {boolean} `true` if close was locally initiated, `false` otherwise.
+   */
+  wasSessionCloseInitiated(): boolean {
+    return this._session.wasCloseInitiated();
   }
 
   /**


### PR DESCRIPTION
- Added session handlers for sender and receiver
- Added methods to sender/receiver/session/connection that indicate whether the close was initiated by itself or not
- Added a boolean property `isConnecting` that indicates whether the entity is in the process of  establishing itself.