### PR TITLE
Only set message_id when provided by caller

### DIFF
--- a/client/lib/eventData.ts
+++ b/client/lib/eventData.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import * as uuid from "uuid/v4";
 import {
   Message, MessageProperties, MessageHeader, Dictionary, messageHeader, messageProperties,
   MessageAnnotations, DeliveryAnnotations
@@ -198,9 +197,6 @@ export namespace EventData {
       for (const prop in data.properties) {
         (msg as any)[prop] = (data.properties as any)[prop];
       }
-    }
-    if (!msg.message_id) {
-      msg.message_id = uuid();
     }
     if (data.applicationProperties) {
       msg.application_properties = data.applicationProperties;

--- a/client/lib/eventHubSender.ts
+++ b/client/lib/eventHubSender.ts
@@ -310,10 +310,6 @@ export class EventHubSender extends LinkEntity {
         }
       }
 
-      if (!batchMessage.message_id) {
-        batchMessage.message_id = uuid();
-      }
-
       // Finally encode the envelope (batch message).
       const encodedBatchMessage = message.encode(batchMessage);
       log.sender("[%s] Sender '%s', sending encoded batch message.",
@@ -365,7 +361,7 @@ export class EventHubSender extends LinkEntity {
         this._sender!.credit, this._sender!.session.outgoing.available());
       if (this._sender!.sendable()) {
         log.sender("[%s] Sender '%s', sending message with id '%s'.", this._context.connectionId,
-          this.name, message.message_id || tag);
+          this.name, message.message_id || tag || '<not specified>');
         let onRejected: Func<EventContext, void>;
         let onReleased: Func<EventContext, void>;
         let onModified: Func<EventContext, void>;


### PR DESCRIPTION
## Description

When sending events using the Node.js Event Hubs SDK, it automatically adds the `message_id` property if one is not specified. This is not the same as the behavior in the .NET SDK and leads to some inconsistency in the received messages sent by the various SDKs.

This PR removes the default ids from the sent messages and updates the unit tests to check both variations to ensure that the id is set correctly. It also tweaks the relevant tests to receive from an offset rather than a time to make them more reliable.
