### PR TITLE
Use isItselfClosed() to determine if sdk initiatied close

### DIFF
--- a/client/changelog.md
+++ b/client/changelog.md
@@ -1,3 +1,7 @@
+### 2018-12-14 1.0.7
+- Use `isItselfClosed()` instead of `isClosed()` in rhea to correctly determine if the sdk initiated close on receiver/sender. 
+This ensures that on connection issues like the ECONNRESET error, the receivers get re-connected properly thus fixing the [bug 174](https://github.com/Azure/azure-event-hubs-node/issues/174)
+
 ### 2018-10-25 1.0.7
 - Only set `message_id` while sending the message, when provided by caller [PR](https://github.com/Azure/azure-event-hubs-node/pull/169).
 

--- a/client/changelog.md
+++ b/client/changelog.md
@@ -1,4 +1,4 @@
-### 2018-12-14 1.0.7
+### 2018-12-14 1.0.8
 - Use `isItselfClosed()` instead of `isClosed()` in rhea to correctly determine if the sdk initiated close on receiver/sender. 
 This ensures that on connection issues like the ECONNRESET error, the receivers get re-connected properly thus fixing the [bug 174](https://github.com/Azure/azure-event-hubs-node/issues/174)
 

--- a/client/lib/connectionContext.ts
+++ b/client/lib/connectionContext.ts
@@ -129,7 +129,7 @@ export namespace ConnectionContext {
           if (!sender.isConnecting) {
             log.error("[%s] calling detached on sender '%s' with address '%s'.",
               connectionContext.connection.id, sender.name, sender.address);
-            sender.detached().catch((err) => {
+            sender.detached(connectionError || contextError).catch((err) => {
               log.error("[%s] An error occurred while reconnecting the sender '%s' with adress '%s' %O.",
                 connectionContext.connection.id, sender.name, sender.address, err);
             });
@@ -145,7 +145,7 @@ export namespace ConnectionContext {
           if (!receiver.isConnecting) {
             log.error("[%s] calling detached on receiver '%s' with address '%s'.",
               connectionContext.connection.id, receiver.name, receiver.address);
-            receiver.detached().catch((err) => {
+            receiver.detached(connectionError || contextError).catch((err) => {
               log.error("[%s] An error occurred while reconnecting the receiver '%s' with adress '%s' %O.",
                 connectionContext.connection.id, receiver.name, receiver.address, err);
             });

--- a/client/lib/eventHubSender.ts
+++ b/client/lib/eventHubSender.ts
@@ -100,7 +100,7 @@ export class EventHubSender extends LinkEntity {
           "The associated error is: %O", this._context.connectionId, this.name,
           this.address, senderError);
       }
-      if (sender && !sender.isClosed()) {
+      if (sender && !sender.isItselfClosed()) {
         if (!this.isConnecting) {
           log.error("[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
             "and the sdk did not initiate this. The sender is not reconnecting. Hence, calling " +
@@ -128,7 +128,7 @@ export class EventHubSender extends LinkEntity {
           "The associated error is: %O", this._context.connectionId, this.name,
           this.address, sessionError);
       }
-      if (sender && !sender.isSessionClosed()) {
+      if (sender && !sender.isSessionItselfClosed()) {
         if (!this.isConnecting) {
           log.error("[%s] 'session_close' event occurred on the session of sender '%s' with " +
             "address '%s' and the sdk did not initiate this. Hence calling detached from the " +
@@ -156,13 +156,11 @@ export class EventHubSender extends LinkEntity {
    */
   async detached(senderError?: AmqpError | Error): Promise<void> {
     try {
-      const wasCloseInitiated = this._sender && this._sender.isClosed();
+      const wasCloseInitiated = this._sender && this._sender.isItselfClosed();
       // Clears the token renewal timer. Closes the link and its session if they are open.
       // Removes the link and its session if they are present in rhea's cache.
       await this._closeLink(this._sender);
-      // For session_close and sender_close this should attempt to reopen
-      // only when the sender(sdk) did not initiate the close) OR
-      // if an error is present and the error is retryable.
+      // We should attempt to reopen only when the sender(sdk) did not initiate the close
       let shouldReopen = false;
       if (senderError && !wasCloseInitiated) {
         const translatedError = translate(senderError);

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/event-hubs",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- Use `isItselfClosed()` instead of `isClosed()` to determine if the sdk has initiated the close
- Pass the connection/context error when calling `detached()` on senders/receivers when the connection gets disconnected
- Remove comment that indicated that we should attempt to reopen sender/receivers for retryable errors even when sdk has intiated the close()

## Reference to any github issues
- #174
- https://github.com/amqp/rhea/issues/170

cc @amarzavery 