### PR TITLE
Update test endpoint that is missing path

### DIFF
--- a/client/tests/client.spec.ts
+++ b/client/tests/client.spec.ts
@@ -47,10 +47,11 @@ describe("EventHubClient", function () {
     });
 
     it("throws when it cannot find the Event Hub path", function () {
+      const endpoint = "Endpoint=sb://abc";
       const test = function () {
-        return EventHubClient.createFromConnectionString("abc");
+        return EventHubClient.createFromConnectionString(endpoint);
       };
-      test.should.throw(Error, `Either provide "path" or the "connectionString": "abc", must contain EntityPath="<path-to-the-entity>".`);
+      test.should.throw(Error, `Either provide "path" or the "connectionString": "${endpoint}", must contain EntityPath="<path-to-the-entity>".`);
     });
 
     it("creates an EventHubClient from a connection string", function () {


### PR DESCRIPTION

## Description

amqp-common 0.1.4 and later introduced a different error for the
invalid endpoint of "abc". This change updates the endpoint so that we
can still test the missing entity path error.

# Reference to any github issues
- Resolves #179
